### PR TITLE
feat(moderation): NudeNet inference API + Redis consumer

### DIFF
--- a/fastapi-mvp/Dockerfile
+++ b/fastapi-mvp/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system deps for ONNX Runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1-mesa-glx libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Pre-download NudeNet model
+RUN python -c "from nudenet import NudeDetector; NudeDetector()"
+
+COPY src/ src/
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/fastapi-mvp/requirements.txt
+++ b/fastapi-mvp/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.2
+uvicorn[standard]==0.30.6
+nudenet>=3.4.2
+redis>=5.0.0
+httpx>=0.27.0

--- a/fastapi-mvp/src/inference.py
+++ b/fastapi-mvp/src/inference.py
@@ -1,0 +1,58 @@
+from nudenet import NudeDetector
+import logging
+
+logger = logging.getLogger("moderation")
+
+# Categories considered unsafe
+UNSAFE_CATEGORIES = {
+    "FEMALE_BREAST_EXPOSED",
+    "FEMALE_GENITALIA_EXPOSED",
+    "MALE_GENITALIA_EXPOSED",
+    "BUTTOCKS_EXPOSED",
+    "ANUS_EXPOSED",
+    "MALE_BREAST_EXPOSED",
+}
+
+# Threshold for blocking
+BLOCK_THRESHOLD = 0.6
+
+detector = None
+
+def load_model():
+    global detector
+    if detector is None:
+        logger.info("Loading NudeNet model...")
+        detector = NudeDetector()
+        logger.info("NudeNet model loaded")
+    return detector
+
+def classify_image(image_path: str) -> dict:
+    """Classify an image and return moderation decision."""
+    model = load_model()
+    detections = model.detect(image_path)
+
+    # Find the most unsafe detection
+    max_unsafe_score = 0.0
+    max_category = None
+
+    for det in detections:
+        label = det.get("class", "")
+        score = det.get("score", 0.0)
+        if label in UNSAFE_CATEGORIES and score > max_unsafe_score:
+            max_unsafe_score = score
+            max_category = label
+
+    if max_unsafe_score >= BLOCK_THRESHOLD:
+        return {
+            "decision": "rejected",
+            "confidence": round(max_unsafe_score, 4),
+            "category": max_category,
+            "all_detections": len(detections),
+        }
+
+    return {
+        "decision": "approved",
+        "confidence": round(1.0 - max_unsafe_score, 4),
+        "category": None,
+        "all_detections": len(detections),
+    }

--- a/fastapi-mvp/src/main.py
+++ b/fastapi-mvp/src/main.py
@@ -1,0 +1,51 @@
+import asyncio
+import logging
+import tempfile
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
+
+from .inference import classify_image, load_model
+from .redis_consumer import listen
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("moderation")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Load model on startup
+    load_model()
+    # Start Redis consumer in background
+    task = asyncio.create_task(listen())
+    yield
+    task.cancel()
+
+app = FastAPI(title="Whispr Moderation Service", version="1.0.0", lifespan=lifespan)
+
+class ModerationResult(BaseModel):
+    decision: str
+    confidence: float
+    category: str | None = None
+    all_detections: int = 0
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "service": "moderation"}
+
+@app.post("/moderate/image", response_model=ModerationResult)
+async def moderate_image(file: UploadFile = File(...)):
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(400, "Only image files are supported")
+
+    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=True) as tmp:
+        content = await file.read()
+        tmp.write(content)
+        tmp.flush()
+        result = classify_image(tmp.name)
+
+    return ModerationResult(**result)
+
+@app.get("/")
+async def root():
+    return {"service": "whispr-moderation", "version": "1.0.0", "docs": "/docs"}

--- a/fastapi-mvp/src/redis_consumer.py
+++ b/fastapi-mvp/src/redis_consumer.py
@@ -1,0 +1,77 @@
+import asyncio
+import json
+import os
+import tempfile
+import logging
+import redis.asyncio as redis
+import httpx
+
+from .inference import classify_image
+
+logger = logging.getLogger("moderation")
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+MEDIA_SERVICE_URL = os.getenv("MEDIA_SERVICE_URL", "http://localhost:3012/media/v1")
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://localhost:9000")
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minioadmin")
+MINIO_BUCKET = os.getenv("MINIO_BUCKET", "whispr-media")
+
+async def download_from_s3(storage_path: str, dest_path: str):
+    """Download file from MinIO/S3 to local temp file."""
+    url = f"{MINIO_ENDPOINT}/{MINIO_BUCKET}/{storage_path}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        with open(dest_path, 'wb') as f:
+            f.write(resp.content)
+
+async def send_verdict(media_id: str, decision: str, score: float, category: str | None):
+    """Send moderation verdict back to media-service."""
+    async with httpx.AsyncClient() as client:
+        await client.patch(
+            f"{MEDIA_SERVICE_URL}/{media_id}/moderation",
+            json={"status": decision, "score": score, "category": category},
+            timeout=10.0,
+        )
+    logger.info(f"Verdict sent for {media_id}: {decision}")
+
+async def process_message(data: dict):
+    """Process a single media.uploaded event."""
+    media_id = data.get("mediaId")
+    storage_path = data.get("storagePath")
+
+    if not media_id or not storage_path:
+        logger.warning(f"Invalid event data: {data}")
+        return
+
+    logger.info(f"Processing media {media_id} at {storage_path}")
+
+    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=True) as tmp:
+        try:
+            await download_from_s3(storage_path, tmp.name)
+            result = classify_image(tmp.name)
+            await send_verdict(media_id, result["decision"], result["confidence"], result["category"])
+        except Exception as e:
+            logger.error(f"Moderation failed for {media_id}: {e}")
+            # On error, approve to avoid blocking legitimate content
+            await send_verdict(media_id, "approved", 0.0, None)
+
+async def listen():
+    """Listen for media.uploaded events on Redis pub/sub."""
+    logger.info("Starting Redis consumer...")
+    r = redis.from_url(REDIS_URL)
+    pubsub = r.pubsub()
+    await pubsub.subscribe("media.uploaded")
+
+    logger.info("Subscribed to media.uploaded channel")
+
+    async for message in pubsub.listen():
+        if message["type"] == "message":
+            try:
+                data = json.loads(message["data"])
+                await process_message(data)
+            except json.JSONDecodeError:
+                logger.warning(f"Invalid JSON in event: {message['data']}")
+            except Exception as e:
+                logger.error(f"Error processing event: {e}")


### PR DESCRIPTION
## Summary
- POST /moderate/image endpoint avec NudeNet NSFW detection
- Redis consumer ecoute media.uploaded events
- Download image depuis MinIO, classification, verdict renvoye au media-service
- Dockerfile avec modele pre-telecharge