### PR TITLE
fix(docker): replace libgl1-mesa-glx by libgl1

### DIFF
--- a/fastapi-mvp/Dockerfile
+++ b/fastapi-mvp/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install system deps for ONNX Runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgl1-mesa-glx libglib2.0-0 \
+    libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .


### PR DESCRIPTION
Le package libgl1-mesa-glx n'existe plus dans python:3.11-slim. Remplace par libgl1.