### PR TITLE
fix(security): hardening Dockerfile et pin SHA actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         working-directory: fastapi-mvp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -41,10 +41,10 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod' || github.ref == 'refs/heads/deploy/prod')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Docker login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
           esac
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./fastapi-mvp
           file: ./fastapi-mvp/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,7 @@ COPY src/ ./src/
 ENV NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+USER appuser
+
 CMD ["python", "src/efficientnet_lite/main.py"]

--- a/fastapi-mvp/Dockerfile
+++ b/fastapi-mvp/Dockerfile
@@ -10,15 +10,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Pre-download NudeNet model so startup is fast and reproducible
-RUN python -c "from nudenet import NudeDetector; NudeDetector()"
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 
-COPY src/ src/
+COPY --chown=appuser:appuser src/ src/
 
 ENV PYTHONUNBUFFERED=1 \
     MOD_BLOCK_THRESHOLD=0.6 \
     MOD_MAX_UPLOAD_MB=10 \
-    MOD_RATE_LIMIT=30/minute
+    MOD_RATE_LIMIT=30/minute \
+    HOME=/home/appuser
+
+USER appuser
+
+# Pre-download NudeNet model so startup is fast and reproducible
+RUN python -c "from nudenet import NudeDetector; NudeDetector()"
 
 EXPOSE 8000
 

--- a/src/efficientnet_lite_gpu/.dockerignore
+++ b/src/efficientnet_lite_gpu/.dockerignore
@@ -1,1 +1,15 @@
 .venv
+__pycache__
+*.pyc
+*.pyo
+.env
+.env.*
+*.key
+*.pem
+*.crt
+.git
+.idea
+.vscode
+*.bat
+README.md
+requirements-fetch-only.txt

--- a/src/efficientnet_lite_gpu/Dockerfile
+++ b/src/efficientnet_lite_gpu/Dockerfile
@@ -1,6 +1,5 @@
 FROM nvcr.io/nvidia/tensorflow:24.07-tf2-py3
 
-# 2️⃣ 基本环境变量
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     LANG=C.UTF-8 \
@@ -12,10 +11,18 @@ COPY requirements.txt /workspace/requirements.txt
 
 RUN pip install --no-cache-dir -r /workspace/requirements.txt
 
-COPY . /workspace/src/efficientnet_lite_gpu
+# Targeted copies to avoid ingesting sensitive or unrelated files
+COPY main.py convert_to_tflite.py test.py config.yaml /workspace/src/efficientnet_lite_gpu/
+COPY tools/ /workspace/src/efficientnet_lite_gpu/tools/
+COPY train/ /workspace/src/efficientnet_lite_gpu/train/
+COPY validation/ /workspace/src/efficientnet_lite_gpu/validation/
+COPY test/ /workspace/src/efficientnet_lite_gpu/test/
 
 ENV PYTHONPATH=/workspace/src
 
 WORKDIR /workspace/src/efficientnet_lite_gpu
+
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /workspace
+USER appuser
 
 CMD ["python", "main.py", "--action=train"]


### PR DESCRIPTION
## Resume

Reponse aux 5 hotspots Sonar (Quality Gate).

## Changements

- Dockerfile (root): ajout user non-root appuser uid 1000
- src/efficientnet_lite_gpu/Dockerfile: ajout user non-root + remplacement du COPY recursif par des COPY cibles (main.py, tools/, train/, validation/, test/, config.yaml, etc) + .dockerignore plus strict (.env, cles, .git, .idea)
- fastapi-mvp/Dockerfile: ajout user non-root et execution du pre-download NudeNet sous appuser
- .github/workflows/ci.yml: pin des actions sur SHA complets
  - actions/checkout v4 -> 34e114876b0b11c390a56381ad16ebd13914f8d5
  - actions/setup-python v5 -> a26af69be951a213d495a4c3e4e4022e16d87065
  - docker/login-action v3 -> c94ce9fb468520275223c153574b00df6fe4bcc9
  - docker/build-push-action v5 -> ca052bb54ab0790a636c9b5f226502c73d547a25

## Tests

- docker build OK pour fastapi-mvp/Dockerfile (image runtime tournant en uid 1000)
- Dockerfiles GPU non buildables localement (pas de NVIDIA), syntaxe validee