### PR TITLE
fix(moderation): ML inference in thread pool + verdict raise_for_status

### DIFF
--- a/fastapi-mvp/src/main.py
+++ b/fastapi-mvp/src/main.py
@@ -71,13 +71,17 @@ async def moderate_image(request: Request, file: UploadFile = File(...)):
     if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(400, "Only image files are supported")
 
+    content = await file.read()
+    if len(content) > MAX_UPLOAD_BYTES:
+        raise HTTPException(413, f"File exceeds {MAX_UPLOAD_MB}MB limit")
+
+    loop = asyncio.get_event_loop()
     with tempfile.NamedTemporaryFile(suffix=".jpg", delete=True) as tmp:
-        content = await file.read()
-        if len(content) > MAX_UPLOAD_BYTES:
-            raise HTTPException(413, f"File exceeds {MAX_UPLOAD_MB}MB limit")
         tmp.write(content)
         tmp.flush()
-        result = classify_image(tmp.name)
+        # classify_image est CPU-bound : on l'exécute dans le thread pool
+        # pour ne pas bloquer l'event loop pendant l'inférence ML
+        result = await loop.run_in_executor(None, classify_image, tmp.name)
 
     return ModerationResult(**result)
 

--- a/fastapi-mvp/src/redis_consumer.py
+++ b/fastapi-mvp/src/redis_consumer.py
@@ -47,12 +47,13 @@ async def download_from_s3(storage_path: str, dest_path: str):
 async def send_verdict(media_id: str, decision: str, score: float, category: str | None):
     """Send moderation verdict back to media-service."""
     async with httpx.AsyncClient() as client:
-        await client.patch(
+        resp = await client.patch(
             f"{MEDIA_SERVICE_URL}/{media_id}/moderation",
             json={"status": decision, "score": score, "category": category},
             timeout=10.0,
         )
-    logger.info(f"Verdict sent for {media_id}: {decision}")
+        resp.raise_for_status()
+    logger.info("Verdict sent for %s: %s", media_id, decision)
 
 async def process_message(data: dict):
     """Process a single media.uploaded event."""


### PR DESCRIPTION
## Summary

- `classify_image` is CPU-bound; calling it directly inside `async def moderate_image` blocked the event loop during every inference, making the service single-threaded under concurrent load. Moved to `run_in_executor`.
- `send_verdict` was not calling `raise_for_status`, so 4xx/5xx from media-service were silently swallowed - verdicts could be lost with no log trace. Fixed.
- Converted one f-string logger call in redis_consumer to `%`-style (avoids string interpolation when log level is filtered).

## Test plan

- [ ] Existing pytest suite passes (`pytest fastapi-mvp/`)
- [ ] Load test: 5 concurrent `/moderate/image` requests complete without queuing behind each other
- [ ] Verify `send_verdict` raises `HTTPStatusError` on non-2xx (unit test mock returning 500 should now propagate to `logger.error`)