### PR TITLE
[WHISPR-1357] fix(moderation): no auto-approve on error

### DIFF
--- a/fastapi-mvp/src/redis_consumer.py
+++ b/fastapi-mvp/src/redis_consumer.py
@@ -35,6 +35,9 @@ MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://localhost:9000")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minioadmin")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "whispr-media")
+# Meme timeout que la route HTTP /moderate/image : protege contre une image
+# piege qui ferait crasher ou tourner NudeNet trop longtemps (DoS / fail-open).
+INFERENCE_TIMEOUT_S = float(os.getenv("MOD_INFERENCE_TIMEOUT_S", "30.0"))
 
 _s3_client = None
 
@@ -93,12 +96,27 @@ async def process_message(data: dict):
     with tempfile.NamedTemporaryFile(suffix=".jpg", delete=True) as tmp:
         try:
             await download_from_s3(storage_path, tmp.name)
-            result = classify_image(tmp.name)
+            # classify_image est CPU-bound : on l'execute dans le thread pool
+            # pour ne pas bloquer l'event loop pendant l'inference ML.
+            # Le timeout protege contre une image piege qui ferait tourner le
+            # detecteur trop longtemps (DoS).
+            loop = asyncio.get_event_loop()
+            result = await asyncio.wait_for(
+                loop.run_in_executor(None, classify_image, tmp.name),
+                timeout=INFERENCE_TIMEOUT_S,
+            )
             await send_verdict(media_id, result["decision"], result["confidence"], result["category"])
+        except asyncio.TimeoutError:
+            logger.error(
+                "Inference timeout for media_id=%s after %.1fs, marking pending",
+                media_id, INFERENCE_TIMEOUT_S,
+            )
+            # ne pas oublier : auto-approuver sur erreur = bypass modération.
+            # On marque pending pour re-classification ou intervention humaine.
+            await send_verdict(media_id, "pending", 0.0, None)
         except Exception as e:
             logger.error(f"Moderation failed for {media_id}: {e}")
-            # On error, approve to avoid blocking legitimate content
-            await send_verdict(media_id, "approved", 0.0, None)
+            await send_verdict(media_id, "pending", 0.0, None)
 
 async def listen():
     """Listen for media.uploaded events on Redis pub/sub."""

--- a/fastapi-mvp/tests/test_redis_consumer.py
+++ b/fastapi-mvp/tests/test_redis_consumer.py
@@ -58,4 +58,61 @@ async def test_process_message_accepts_safe_path():
             "mediaId": "m2",
             "storagePath": "media/ok.jpg",
         })
-    sv.assert_called_once()
+    sv.assert_called_once_with("m2", "approved", 0.9, None)
+
+
+@pytest.mark.asyncio
+async def test_process_message_inference_error_marks_pending():
+    """Si classify_image plante, on doit marquer pending PAS approved.
+    Sinon un attaquant qui crashe l'inference bypass la moderation.
+    """
+    def boom(_path):
+        raise RuntimeError("nudenet crashed on craft image")
+
+    with patch.object(redis_consumer, "download_from_s3", new=AsyncMock()), \
+         patch.object(redis_consumer, "send_verdict", new=AsyncMock()) as sv, \
+         patch.object(redis_consumer, "classify_image", side_effect=boom):
+        await redis_consumer.process_message({
+            "mediaId": "m3",
+            "storagePath": "media/crash.jpg",
+        })
+
+    sv.assert_called_once_with("m3", "pending", 0.0, None)
+
+
+@pytest.mark.asyncio
+async def test_process_message_inference_timeout_marks_pending():
+    """Si l'inference depasse le timeout, on doit marquer pending."""
+    def slow(_path):
+        # bloque assez longtemps pour declencher asyncio.wait_for
+        import time
+        time.sleep(2.0)
+        return {"decision": "approved", "confidence": 0.9, "category": None}
+
+    with patch.object(redis_consumer, "download_from_s3", new=AsyncMock()), \
+         patch.object(redis_consumer, "send_verdict", new=AsyncMock()) as sv, \
+         patch.object(redis_consumer, "classify_image", side_effect=slow), \
+         patch.object(redis_consumer, "INFERENCE_TIMEOUT_S", 0.1):
+        await redis_consumer.process_message({
+            "mediaId": "m4",
+            "storagePath": "media/slow.jpg",
+        })
+
+    sv.assert_called_once_with("m4", "pending", 0.0, None)
+
+
+@pytest.mark.asyncio
+async def test_process_message_download_error_marks_pending():
+    """Si le download S3 echoue, on doit marquer pending PAS approved."""
+    async def boom_download(_path, _dest):
+        raise IOError("s3 unreachable")
+
+    with patch.object(redis_consumer, "download_from_s3", new=boom_download), \
+         patch.object(redis_consumer, "send_verdict", new=AsyncMock()) as sv, \
+         patch.object(redis_consumer, "classify_image"):
+        await redis_consumer.process_message({
+            "mediaId": "m5",
+            "storagePath": "media/missing.jpg",
+        })
+
+    sv.assert_called_once_with("m5", "pending", 0.0, None)


### PR DESCRIPTION
## Summary

- Le consumer Redis (`fastapi-mvp/src/redis_consumer.py:98-101`) basculait en `approved` sur toute exception remontee de `classify_image`. Un attaquant capable de crasher NudeNet (image piege, magic bytes corrompus apres probe PIL, OOM) pouvait bypass 100% de la moderation.
- Pas de timeout cote consumer alors que la route HTTP `/moderate/image` en a un (30s) - une image lourde pouvait monopoliser le worker indefiniment.

## Fix

- Wrap `classify_image` dans `asyncio.wait_for(timeout=INFERENCE_TIMEOUT_S)` + `loop.run_in_executor` (meme pattern que `main.py:139-146`).
- Sur exception ou `asyncio.TimeoutError` : `send_verdict(media_id, "pending", 0.0, None)` au lieu de `approved`. Le contrat `moderation.proto` accepte deja `pending` (ligne 22), donc zero breaking change cote consumer (media-service).
- Comportement utilisateur : le media reste invisible jusqu a re-classification ou intervention humaine, plutot que d etre auto-approuve.

## Test plan

- [x] `pytest tests/test_redis_consumer.py` (21 tests, 4 nouveaux)
  - inference qui throw -> assert send_verdict pending (pas approved)
  - timeout -> assert send_verdict pending
  - download S3 qui throw -> assert send_verdict pending
  - happy path inchange (approved/rejected selon score)
- [x] `ruff check src/ tests/` propre
- [x] Suite complete : 36 tests passed

## Note

`pending_review` n existe pas dans le proto (`approved | rejected | pending`). Utilise `pending` pour conformite. Si l equipe veut un statut plus precis (`error_inference`, `pending_review`), ouvrir un suivi cote `media-service/proto/moderation.proto`.

Closes WHISPR-1357