### PR TITLE
[WHISPR-1368] fix(moderation): timeout HTTP route renvoie pending et lock sur load_model

### DIFF
--- a/fastapi-mvp/src/inference.py
+++ b/fastapi-mvp/src/inference.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 import time
 
 from nudenet import NudeDetector
@@ -20,15 +21,24 @@ UNSAFE_CATEGORIES = {
 BLOCK_THRESHOLD = float(os.getenv("MOD_BLOCK_THRESHOLD", "0.6"))
 
 detector = None
+# Lock pour eviter le double-load si deux requetes arrivent au cold-start
+# avant que le lifespan ait fini d'instancier NudeDetector. Sans ca, on
+# peut charger le modele 2x (waste memoire) ou laisser un detector partiel.
+_load_lock = threading.Lock()
 
 
 def load_model():
     global detector
-    if detector is None:
-        logger.info("Loading NudeNet model...")
-        t0 = time.perf_counter()
-        detector = NudeDetector()
-        logger.info("NudeNet model loaded in %.2fs", time.perf_counter() - t0)
+    # double-checked locking : verif rapide sans lock pour le hot path
+    if detector is not None:
+        return detector
+    with _load_lock:
+        # re-verifier sous lock au cas ou un autre thread a charge entre temps
+        if detector is None:
+            logger.info("Loading NudeNet model...")
+            t0 = time.perf_counter()
+            detector = NudeDetector()
+            logger.info("NudeNet model loaded in %.2fs", time.perf_counter() - t0)
     return detector
 
 

--- a/fastapi-mvp/src/main.py
+++ b/fastapi-mvp/src/main.py
@@ -143,7 +143,15 @@ async def moderate_image(request: Request, file: UploadFile = File(...)):
             )
         except asyncio.TimeoutError:
             logger.warning("Inference timeout after %.1fs", INFERENCE_TIMEOUT_S)
-            raise HTTPException(503, "Inference timeout")
+            # cohérent avec WHISPR-1357 : pas de fail-open, on renvoie pending
+            # pour que media-service marque le media a re-classifier ou
+            # passer en review humaine.
+            return ModerationResult(
+                decision="pending",
+                confidence=0.0,
+                category=None,
+                all_detections=0,
+            )
 
     return ModerationResult(**result)
 

--- a/fastapi-mvp/tests/test_api.py
+++ b/fastapi-mvp/tests/test_api.py
@@ -123,8 +123,12 @@ def test_moderate_image_rejects_svg(client):
     assert r.status_code == 415
 
 
-def test_moderate_image_returns_503_on_inference_timeout(monkeypatch):
-    """Si classify_image prend plus que MOD_INFERENCE_TIMEOUT_S -> 503."""
+def test_moderate_image_returns_pending_on_inference_timeout(monkeypatch):
+    """Si classify_image depasse MOD_INFERENCE_TIMEOUT_S -> 200 + decision=pending.
+
+    On ne renvoie pas 503 / fail-open : cohérent avec WHISPR-1357, on marque
+    pending pour que media-service re-classifie ou passe en review humaine.
+    """
     monkeypatch.setenv("MOD_INFERENCE_TIMEOUT_S", "0.05")
 
     import time
@@ -145,7 +149,11 @@ def test_moderate_image_returns_503_on_inference_timeout(monkeypatch):
                     "/moderate/image",
                     files={"file": ("a.png", _make_png_bytes(), "image/png")},
                 )
-    assert r.status_code == 503
+    assert r.status_code == 200
+    body = r.json()
+    assert body["decision"] == "pending"
+    assert body["confidence"] == 0.0
+    assert body["category"] is None
 
 
 def test_moderate_image_rejects_when_auth_header_wrong(auth_client):

--- a/fastapi-mvp/tests/test_inference.py
+++ b/fastapi-mvp/tests/test_inference.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import patch
 
 from src import inference
@@ -56,3 +57,28 @@ def test_classify_image_picks_highest_unsafe_score():
     assert result["decision"] == "rejected"
     assert result["category"] == "FEMALE_GENITALIA_EXPOSED"
     assert result["confidence"] == 0.9
+
+
+def test_load_model_loads_only_once_under_concurrent_calls():
+    """N threads qui appellent load_model en parallele ne doivent
+    instancier NudeDetector qu'une seule fois (pas de double-load)."""
+    inference.detector = None
+    call_count = 0
+
+    class FakeDetector:
+        def __init__(self):
+            nonlocal call_count
+            call_count += 1
+            # petite pause pour favoriser la collision entre threads
+            import time as _t
+            _t.sleep(0.05)
+
+    with patch.object(inference, "NudeDetector", FakeDetector):
+        threads = [threading.Thread(target=inference.load_model) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert call_count == 1
+    inference.detector = None


### PR DESCRIPTION
## Contexte

Suite a WHISPR-1357 (no fail-open : sur erreur d'inference, on renvoie pending au lieu d'auto-approve), il restait deux trous coherents a colmater :

1. **Route HTTP /moderate/image** : sur timeout d'inference, on raisait `HTTPException 503 "Inference timeout"`. Un client mal configure pouvait considerer une 5xx comme une erreur transitoire et fail-open. Le redis_consumer a deja le bon comportement (envoie `pending`) ; on aligne la route HTTP.
2. **load_model lazy** : `if detector is None: detector = NudeDetector()` n'a aucune protection contre la concurrence. Si 2 requetes arrivent au cold-start (ex : redemarrage k8s avec readinessProbe trop laxe ou bypass du lifespan en mode test), on peut instancier NudeDetector deux fois.

## Changements

- `src/main.py` : sur `asyncio.TimeoutError`, retour `ModerationResult(decision="pending", confidence=0.0, ...)` au lieu de 503. Compatible avec le contract proto `moderation.proto` (status accepte `approved/rejected/pending`).
- `src/inference.py` : `threading.Lock` + double-checked locking dans `load_model()`. Hot path inchanged (verif rapide sans lock), cold path serialise les inits concurrents.
- `tests/test_api.py` : test renomme `test_moderate_image_returns_pending_on_inference_timeout` qui assert 200 + `decision=pending`.
- `tests/test_inference.py` : nouveau test `test_load_model_loads_only_once_under_concurrent_calls` qui lance 8 threads en parallele et verifie que `NudeDetector` n'est instancie qu'une seule fois.

## Behavior change

| Scenario                              | Avant                       | Apres                              |
|---------------------------------------|-----------------------------|------------------------------------|
| Inference timeout sur /moderate/image | HTTP 503                    | HTTP 200, decision=pending         |
| 2 requetes concurrentes au cold-start | Possible double-load NudeNet| 1 seul load (lock + DCL)           |

## Tests

- `pytest tests/` : 37/37 verts en local
- `ruff check src tests` : clean

## Plan deploy

- Merge dans `deploy/preprod` -> ArgoCD bumpe l'image -> kubectl rollout
- Smoke-test : POST /moderate/image avec une image lourde simulee, verifier 200 + `pending` au lieu de 503